### PR TITLE
#41 Added Help bar button item + large titles

### DIFF
--- a/99reddits.xcodeproj/project.pbxproj
+++ b/99reddits.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		FE91DCA41F789C61005F5B7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FE91DCA31F789C61005F5B7F /* Assets.xcassets */; };
 		FECE3A4F1F87381300306B26 /* NSData+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = FECE3A4E1F87381300306B26 /* NSData+Extensions.m */; };
 		FEE776BD1F89C6AE003703A1 /* FeedbackController.m in Sources */ = {isa = PBXBuildFile; fileRef = FEE776BC1F89C6AE003703A1 /* FeedbackController.m */; };
+		FEE776BF1F89D4D7003703A1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FEE776BE1F89D4D7003703A1 /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -507,6 +508,7 @@
 		FECE3A4E1F87381300306B26 /* NSData+Extensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSData+Extensions.m"; sourceTree = "<group>"; };
 		FEE776BB1F89C6AE003703A1 /* FeedbackController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FeedbackController.h; sourceTree = "<group>"; };
 		FEE776BC1F89C6AE003703A1 /* FeedbackController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FeedbackController.m; sourceTree = "<group>"; };
+		FEE776BE1F89D4D7003703A1 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -945,6 +947,7 @@
 			isa = PBXGroup;
 			children = (
 				8D6C5D1A164ACCCC008A98A7 /* MainWindow.xib */,
+				FEE776BE1F89D4D7003703A1 /* LaunchScreen.storyboard */,
 				8D6C5D0E164ACCCC008A98A7 /* MainView */,
 				8D6C5CFE164ACCCC008A98A7 /* AlbumView */,
 			);
@@ -1092,7 +1095,7 @@
 				ORGANIZATIONNAME = "99 reddits";
 				TargetAttributes = {
 					8D5080011445923700788875 = {
-						DevelopmentTeam = Z5S4TLR4D3;
+						DevelopmentTeam = 2DLBN8DKBU;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 					};
@@ -1154,6 +1157,7 @@
 				843903661A749747007B9EFF /* CommentBlueIcon@3x.png in Resources */,
 				8D6C5D2F164ACCCC008A98A7 /* AlbumViewController.xib in Resources */,
 				843903801A749747007B9EFF /* FireIcon.png in Resources */,
+				FEE776BF1F89D4D7003703A1 /* LaunchScreen.storyboard in Resources */,
 				84B9DFF21A7928E800EA3CF0 /* Maximize@3x.png in Resources */,
 				8439039B1A749747007B9EFF /* TopIcon.png in Resources */,
 				843903621A749747007B9EFF /* ClearButton@2x.png in Resources */,
@@ -1511,11 +1515,10 @@
 			baseConfigurationReference = 6CDE3CB9CBB3873CA2C7D9A5 /* Pods-99reddits.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = Z5S4TLR4D3;
+				DEVELOPMENT_TEAM = 2DLBN8DKBU;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",
@@ -1544,11 +1547,10 @@
 			baseConfigurationReference = A957AF9D16111BB0F57DA71A /* Pods-99reddits.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = Z5S4TLR4D3;
+				DEVELOPMENT_TEAM = 2DLBN8DKBU;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)",

--- a/99reddits.xcodeproj/project.pbxproj
+++ b/99reddits.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		FE85689E1F8097D90033EC11 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE85689D1F8097D90033EC11 /* ImageLoader.swift */; };
 		FE91DCA41F789C61005F5B7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FE91DCA31F789C61005F5B7F /* Assets.xcassets */; };
 		FECE3A4F1F87381300306B26 /* NSData+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = FECE3A4E1F87381300306B26 /* NSData+Extensions.m */; };
+		FEE776BD1F89C6AE003703A1 /* FeedbackController.m in Sources */ = {isa = PBXBuildFile; fileRef = FEE776BC1F89C6AE003703A1 /* FeedbackController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -504,6 +505,8 @@
 		FE91DCA31F789C61005F5B7F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FECE3A4D1F87381300306B26 /* NSData+Extensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+Extensions.h"; sourceTree = "<group>"; };
 		FECE3A4E1F87381300306B26 /* NSData+Extensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSData+Extensions.m"; sourceTree = "<group>"; };
+		FEE776BB1F89C6AE003703A1 /* FeedbackController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FeedbackController.h; sourceTree = "<group>"; };
+		FEE776BC1F89C6AE003703A1 /* FeedbackController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FeedbackController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1011,6 +1014,8 @@
 				847D5F721A7A3C9F00173A01 /* URLProvider.m */,
 				8D6C5D2A164ACCCC008A98A7 /* UserDef.h */,
 				8D6C5D2B164ACCCC008A98A7 /* UserDef.m */,
+				FEE776BB1F89C6AE003703A1 /* FeedbackController.h */,
+				FEE776BC1F89C6AE003703A1 /* FeedbackController.m */,
 				FE4738751F7CA0C300EC4828 /* ReviewManager.h */,
 				FE4738761F7CA0C300EC4828 /* ReviewManager.m */,
 				FE85689D1F8097D90033EC11 /* ImageLoader.swift */,
@@ -1334,6 +1339,7 @@
 				8D68FDCD14F8909000CDCF66 /* NIError.m in Sources */,
 				8D68FDCE14F8909000CDCF66 /* NIFoundationMethods.m in Sources */,
 				8D68FDCF14F8909000CDCF66 /* NIInMemoryCache.m in Sources */,
+				FEE776BD1F89C6AE003703A1 /* FeedbackController.m in Sources */,
 				8D68FDD014F8909000CDCF66 /* NINavigationAppearance.m in Sources */,
 				8D68FDD114F8909000CDCF66 /* NINetworkActivity.m in Sources */,
 				8D68FDD214F8909000CDCF66 /* NINonEmptyCollectionTesting.m in Sources */,

--- a/99reddits/99reddits-Info.plist
+++ b/99reddits/99reddits-Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>This allows you to save photos.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -64,14 +62,18 @@
 	<string>MainWindow</string>
 	<key>NSMainNibFile~ipad</key>
 	<string>MainWindowPad</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This allows you to save photos.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This allows you to save photos.</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
 	<key>UIRequiresFullScreen</key>
 	<string>YES</string>
 	<key>UIStatusBarHidden</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/99reddits/Shared/FeedbackController.h
+++ b/99reddits/Shared/FeedbackController.h
@@ -1,0 +1,15 @@
+//
+//  FeedbackController.h
+//  99reddits
+//
+//  Created by Pietro Rea on 10/7/17.
+//  Copyright © 2017 99 reddits. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface FeedbackController : NSObject
+
+- (void)presentFeedbackViewController:(UIViewController *)presenter;
+
+@end

--- a/99reddits/Shared/FeedbackController.m
+++ b/99reddits/Shared/FeedbackController.m
@@ -1,0 +1,58 @@
+//
+//  FeedbackController.m
+//  99reddits
+//
+//  Created by Pietro Rea on 10/7/17.
+//  Copyright © 2017 99 reddits. All rights reserved.
+//
+
+@import UIKit;
+@import MessageUI;
+#import "FeedbackController.h"
+
+@interface FeedbackController() <MFMailComposeViewControllerDelegate>
+
+@end
+
+@implementation FeedbackController
+
+- (void)presentFeedbackViewController:(UIViewController *)presenter {
+
+    if (![MFMailComposeViewController canSendMail]) {
+        [self presentAlertViewController:presenter];
+        return;
+    }
+
+    NSString *contentString = [NSString stringWithFormat:@"\n\n\n---\n99 reddits v%@\n%@ / iOS %@",
+                               [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
+                               deviceName(),
+                               [[UIDevice currentDevice] systemVersion]];
+
+    MFMailComposeViewController *mailComposeViewController = [[MFMailComposeViewController alloc] init];
+    mailComposeViewController.mailComposeDelegate = self;
+
+    [mailComposeViewController setSubject:@"99 reddits feedback"];
+    [mailComposeViewController setToRecipients:[NSArray arrayWithObject:@"99reddits@lensie.com"]];
+    [mailComposeViewController setMessageBody:contentString isHTML:NO];
+
+    [presenter presentViewController:mailComposeViewController animated:YES completion:nil];
+}
+
+- (void)presentAlertViewController:(UIViewController *)presenter {
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"Cannot send email" message:@"Your device is not configured to set email." preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *action = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+
+    }];
+
+    [alertController addAction:action];
+
+    [presenter presentViewController:alertController animated:YES completion:nil];
+}
+
+#pragma mark - MFMailComposeViewControllerDelegate
+
+- (void)mailComposeController:(MFMailComposeViewController *)controller didFinishWithResult:(MFMailComposeResult)result error:(nullable NSError *)error {
+    [controller dismissViewControllerAnimated:YES completion:nil];
+}
+
+@end

--- a/99reddits/iPhone/AlbumView/AlbumViewController.m
+++ b/99reddits/iPhone/AlbumView/AlbumViewController.m
@@ -43,7 +43,7 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-	
+
 	appDelegate = (RedditsAppDelegate *)[[UIApplication sharedApplication] delegate];
 
   self.refreshQueue = [[NSOperationQueue alloc] init];
@@ -51,6 +51,10 @@
 	
 	self.title = subReddit.nameString;
 	self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:subReddit.nameString style:UIBarButtonItemStylePlain target:nil action:nil];
+
+    if (@available(iOS 11.0, *)) {
+        self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+    }
 	
 	if (bFavorites) {
 		[tabBar removeFromSuperview];

--- a/99reddits/iPhone/AlbumView/PhotoViewController.m
+++ b/99reddits/iPhone/AlbumView/PhotoViewController.m
@@ -55,8 +55,12 @@
 	[whiteButton addTarget:self action:@selector(onFavoriteButton:) forControlEvents:UIControlEventTouchUpInside];
 	favoriteWhiteItem = [[UIBarButtonItem alloc] initWithCustomView:whiteButton];
 	
-	self.navigationItem.rightBarButtonItem = favoriteRedItem;
-	
+    self.navigationItem.rightBarButtonItem = favoriteRedItem;
+
+    if (@available(iOS 11.0, *)) {
+        self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+    }
+
 	appDelegate = (RedditsAppDelegate *)[[UIApplication sharedApplication] delegate];
 	
 	self.photoAlbumView.loadingImage = [UIImage imageWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"DefaultPhotoLarge" ofType:@"png"]];

--- a/99reddits/iPhone/LaunchScreen.storyboard
+++ b/99reddits/iPhone/LaunchScreen.storyboard
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Mno-ZM-Uti">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--99 reddits-->
+        <scene sceneID="DRY-4x-xNL">
+            <objects>
+                <tableViewController id="cHR-fk-SM7" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="55" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="fFi-AZ-bag">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Ci2-4f-fFc">
+                                <rect key="frame" x="0.0" y="28" width="375" height="55"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ci2-4f-fFc" id="CtU-Th-zhg">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="54.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="cHR-fk-SM7" id="msx-we-S5j"/>
+                            <outlet property="delegate" destination="cHR-fk-SM7" id="obB-MS-74c"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="99 reddits" id="cWP-Ej-XMN"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iWw-uI-jte" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-135" y="260"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="mHG-Pw-Eh1">
+            <objects>
+                <navigationController id="Mno-ZM-Uti" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="veF-or-EwA">
+                        <rect key="frame" x="0.0" y="20" width="375" height="96"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="cHR-fk-SM7" kind="relationship" relationship="rootViewController" id="PD0-A4-MFB"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CnE-qu-jDp" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1087" y="260"/>
+        </scene>
+    </scenes>
+</document>

--- a/99reddits/iPhone/MainView/MainViewController.h
+++ b/99reddits/iPhone/MainView/MainViewController.h
@@ -13,7 +13,6 @@
 @class SubRedditItem;
 
 @interface MainViewController : UITableViewController <ASIHTTPRequestDelegate> {
-	IBOutlet UIBarButtonItem *settingsItem;
 	IBOutlet UIBarButtonItem *editItem;
 	IBOutlet UIBarButtonItem *doneItem;
 	IBOutlet UIView *footerView;

--- a/99reddits/iPhone/MainView/MainViewController.m
+++ b/99reddits/iPhone/MainView/MainViewController.m
@@ -12,10 +12,13 @@
 #import "AlbumViewController.h"
 #import "RedditsViewController.h"
 #import "UserDef.h"
+#import "FeedbackController.h"
 #import "_9reddits-Swift.h"
 
 @interface MainViewController ()
 
+@property (strong, nonatomic) IBOutlet UIBarButtonItem *helpBarButtonItem;
+@property (strong, nonatomic) FeedbackController *feedbackController;
 @property (strong, nonatomic) NSOperationQueue *refreshQueue;
 
 @end
@@ -37,6 +40,8 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+    self.feedbackController = [[FeedbackController alloc] init];
+
 	appDelegate = (RedditsAppDelegate *)[[UIApplication sharedApplication] delegate];
 	subRedditsArray = appDelegate.subRedditsArray;
 	
@@ -51,9 +56,12 @@
 	});
 
 	self.title = @"99 reddits";
-	
-	self.navigationItem.leftBarButtonItems = [NSArray arrayWithObjects:settingsItem, nil];
-	self.navigationItem.rightBarButtonItems = [NSArray arrayWithObjects:editItem, nil];
+    if (@available(iOS 11.0, *)) {
+        self.navigationController.navigationBar.prefersLargeTitles = YES;
+    }
+
+    self.navigationItem.leftBarButtonItems = @[self.helpBarButtonItem];
+    self.navigationItem.rightBarButtonItems = @[editItem];
 
 	self.refreshQueue = [[NSOperationQueue alloc] init];
 	[self.refreshQueue setMaxConcurrentOperationCount:5];
@@ -109,17 +117,21 @@
 	if (self.editing) {
 		self.refreshControl = nil;
 		
-		settingsItem.enabled = NO;
+		self.helpBarButtonItem.enabled = NO;
 
 		self.navigationItem.rightBarButtonItems = [NSArray arrayWithObjects:doneItem, nil];
 	}
 	else {
 		self.refreshControl = refreshControl;
 		
-		settingsItem.enabled = YES;
+		self.helpBarButtonItem.enabled = YES;
 
 		self.navigationItem.rightBarButtonItems = [NSArray arrayWithObjects:editItem, nil];
 	}
+}
+
+- (IBAction)helpBarButtonItem:(UIBarButtonItem *)sender {
+    [self.feedbackController presentFeedbackViewController:self];
 }
 
 - (IBAction)onAddButton:(id)sender {

--- a/99reddits/iPhone/MainView/MainViewController.xib
+++ b/99reddits/iPhone/MainView/MainViewController.xib
@@ -15,6 +15,7 @@
                 <outlet property="doneItem" destination="26" id="31"/>
                 <outlet property="editItem" destination="27" id="32"/>
                 <outlet property="footerView" destination="j8D-Fp-Faa" id="3ic-Ph-ltt"/>
+                <outlet property="helpBarButtonItem" destination="4yB-Z2-gGD" id="GSg-qi-J1a"/>
                 <outlet property="view" destination="22" id="23"/>
             </connections>
         </placeholder>
@@ -28,6 +29,7 @@
                 <outlet property="dataSource" destination="-1" id="24"/>
                 <outlet property="delegate" destination="-1" id="25"/>
             </connections>
+            <point key="canvasLocation" x="-84" y="-52"/>
         </tableView>
         <barButtonItem systemItem="done" id="26">
             <connections>
@@ -66,5 +68,10 @@
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
         </view>
+        <barButtonItem title="Help" id="4yB-Z2-gGD" userLabel="Help Item">
+            <connections>
+                <action selector="helpBarButtonItem:" destination="-1" id="U3E-M0-lXg"/>
+            </connections>
+        </barButtonItem>
     </objects>
 </document>


### PR DESCRIPTION
@TheLoombot please review

- Added a left bar button item to the main view that says "Help"
- This brings up an email compose screen like before, or an error alert if you haven't set up `Mail.app` or can't send emails (previously missing)
- Also playing with iOS 11 style large titles. Being a good iOS citizen and turning them on. It looks like the screenshot below. Also switched to a storyboard instead of launch images. That will play nicer with the large titles + also helps for iPhone X support further down the line.

![simulator screen shot - iphone 8 - 2017-10-07 at 23 54 29](https://user-images.githubusercontent.com/1264371/31313776-e22ad9a6-abba-11e7-8528-c222294fd55a.png)
