### PR TITLE
Restoring pattern Frank setup for customizing share contents based on…

### DIFF
--- a/99reddits.xcodeproj/project.pbxproj
+++ b/99reddits.xcodeproj/project.pbxproj
@@ -163,6 +163,8 @@
 		8DB620581770584200D744A4 /* Accounts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DA00401145AB959000F6E07 /* Accounts.framework */; };
 		8DB6205A1770584A00D744A4 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DB620591770584A00D744A4 /* AdSupport.framework */; };
 		9C3E7EA41DF495B700A70F4C /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C3E7EA31DF495B700A70F4C /* Crashlytics.framework */; };
+		9C6584101FA028A500D95BD5 /* TitleProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C65840F1FA028A500D95BD5 /* TitleProvider.m */; };
+		9C6584141FA02B2800D95BD5 /* URLProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C6584131FA02B2800D95BD5 /* URLProvider.m */; };
 		9C6EC04B1CACC88900DEB36D /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C6EC04A1CACC88900DEB36D /* Fabric.framework */; };
 		9C6EC04D1CACC9BF00DEB36D /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C6EC04C1CACC9BF00DEB36D /* libc++.tbd */; };
 		9C6EC04F1CACC9C700DEB36D /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C6EC04E1CACC9C700DEB36D /* libz.tbd */; };
@@ -421,6 +423,10 @@
 		8DB620591770584A00D744A4 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		9C0334BA16B2391800A2F5D3 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = "<group>"; };
 		9C3E7EA31DF495B700A70F4C /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = "<group>"; };
+		9C65840F1FA028A500D95BD5 /* TitleProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TitleProvider.m; sourceTree = "<group>"; };
+		9C6584111FA028BF00D95BD5 /* TitleProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TitleProvider.h; sourceTree = "<group>"; };
+		9C6584121FA02AFE00D95BD5 /* URLProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = URLProvider.h; sourceTree = "<group>"; };
+		9C6584131FA02B2800D95BD5 /* URLProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = URLProvider.m; sourceTree = "<group>"; };
 		9C6EC0481CACC62900DEB36D /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
 		9C6EC04A1CACC88900DEB36D /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
 		9C6EC04C1CACC9BF00DEB36D /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
@@ -894,6 +900,10 @@
 				FE85689C1F8097D90033EC11 /* 99reddits-Bridging-Header.h */,
 				FECE3A4D1F87381300306B26 /* NSData+Extensions.h */,
 				FECE3A4E1F87381300306B26 /* NSData+Extensions.m */,
+				9C65840F1FA028A500D95BD5 /* TitleProvider.m */,
+				9C6584111FA028BF00D95BD5 /* TitleProvider.h */,
+				9C6584121FA02AFE00D95BD5 /* URLProvider.h */,
+				9C6584131FA02B2800D95BD5 /* URLProvider.m */,
 			);
 			name = Shared;
 			path = 99reddits/Shared;
@@ -1221,10 +1231,12 @@
 				8D6C5D35164ACCCC008A98A7 /* AddViewController.m in Sources */,
 				8D6C5D37164ACCCC008A98A7 /* MainViewCell.m in Sources */,
 				8D6C5D38164ACCCC008A98A7 /* MainViewController.m in Sources */,
+				9C6584141FA02B2800D95BD5 /* URLProvider.m in Sources */,
 				8D6C5D3A164ACCCC008A98A7 /* RedditsViewController.m in Sources */,
 				8D6C5D40164ACCCC008A98A7 /* MBProgressHUD.m in Sources */,
 				8D6C5D41164ACCCC008A98A7 /* PhotoItem.m in Sources */,
 				FE85689E1F8097D90033EC11 /* ImageLoader.swift in Sources */,
+				9C6584101FA028A500D95BD5 /* TitleProvider.m in Sources */,
 				8D6C5D43164ACCCC008A98A7 /* SubRedditItem.m in Sources */,
 				8D6C5D44164ACCCC008A98A7 /* UserDef.m in Sources */,
 				8D66C1AE164BA38300EAC2C0 /* RedditsAppDelegate.m in Sources */,

--- a/99reddits/Shared/TitleProvider.h
+++ b/99reddits/Shared/TitleProvider.h
@@ -1,0 +1,15 @@
+//
+//  TitleProvider.h
+//  99reddits
+//
+//  Created by aloomba on 10/24/17.
+//  Copyright © 2017 99 reddits. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface TitleProvider : UIActivityItemProvider <UIActivityItemSource> {
+    NSString *title;
+}
+
+@end

--- a/99reddits/Shared/TitleProvider.m
+++ b/99reddits/Shared/TitleProvider.m
@@ -1,0 +1,34 @@
+//
+//  TitleProvider.m
+//  99reddits
+//
+//  Created by aloomba on 10/24/17.
+//  Copyright © 2017 99 reddits. All rights reserved.
+//
+
+#import "TitleProvider.h"
+
+@implementation TitleProvider
+
+- (id)initWithPlaceholderItem:(id)placeholderItem {
+    self = [super initWithPlaceholderItem:placeholderItem];
+    if (self) {
+        title = placeholderItem;
+    }
+    
+    return self;
+}
+
+- (id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType {
+    if ([activityType isEqualToString:UIActivityTypeCopyToPasteboard] || [activityType isEqualToString:UIActivityTypeMessage])
+        return nil;
+    
+    return title;
+}
+
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController {
+    return self.placeholderItem;
+}
+
+@end
+

--- a/99reddits/Shared/URLProvider.h
+++ b/99reddits/Shared/URLProvider.h
@@ -1,0 +1,16 @@
+//
+//  URLProvider.h
+//  99reddits
+//
+//  Created by aloomba on 10/24/17.
+//  Copyright © 2017 99 reddits. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface URLProvider : UIActivityItemProvider <UIActivityItemSource> {
+    NSURL *url;
+}
+
+@end
+

--- a/99reddits/Shared/URLProvider.m
+++ b/99reddits/Shared/URLProvider.m
@@ -1,0 +1,34 @@
+//
+//  URLProvider.m
+//  99reddits
+//
+//  Created by aloomba on 10/24/17.
+//  Copyright © 2017 99 reddits. All rights reserved.
+//
+
+#import "URLProvider.h"
+
+@implementation URLProvider
+
+- (id)initWithPlaceholderItem:(id)placeholderItem {
+    self = [super initWithPlaceholderItem:placeholderItem];
+    if (self) {
+        url = placeholderItem;
+    }
+    
+    return self;
+}
+
+- (id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType {
+    if ([activityType isEqualToString:UIActivityTypeCopyToPasteboard] || [activityType isEqualToString:UIActivityTypeMessage])
+        return nil;
+    
+    return url;
+}
+
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController {
+    return self.placeholderItem;
+}
+
+@end
+

--- a/99reddits/iPhone/AlbumView/PhotoViewController.m
+++ b/99reddits/iPhone/AlbumView/PhotoViewController.m
@@ -12,6 +12,8 @@
 #import "CommentViewController.h"
 #import "NSData+Extensions.h"
 #import "_9reddits-Swift.h"
+#import "TitleProvider.h"
+#import "URLProvider.h"
 
 @interface PhotoViewController()
 
@@ -268,16 +270,25 @@
 #pragma mark - UIActivityViewController sharing
 
 - (void)shareImage:(UIImage *)image title:(NSString *)title url:(NSURL *)url {
-    [self shareActivityItems:@[image, title, url]];
+
+    TitleProvider *titleItem = [[TitleProvider alloc] initWithPlaceholderItem:title];
+    URLProvider *urlItem = [[URLProvider alloc] initWithPlaceholderItem:url];
+    
+    [self shareActivityItems:@[image, titleItem, urlItem]];
 }
 
 - (void)shareGifData:(NSData *)data title:(NSString *)title url:(NSURL *)url {
-    [self shareActivityItems:@[data, title, url]];
+
+    TitleProvider *titleItem = [[TitleProvider alloc] initWithPlaceholderItem:title];
+    URLProvider *urlItem = [[URLProvider alloc] initWithPlaceholderItem:url];
+    
+    [self shareActivityItems:@[data, titleItem, urlItem]];
 }
 
 - (void)shareActivityItems:(NSArray *)activityItems {
 
     NSArray *excludedActivityTypes = @[UIActivityTypeAssignToContact, UIActivityTypeAddToReadingList, UIActivityTypePrint];
+
     UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:activityItems applicationActivities:@[]];
     activityViewController.excludedActivityTypes = excludedActivityTypes;
 


### PR DESCRIPTION
… activity type (Messages, Clipboard) 

Issue #58 

Hopefully I didn't muck this one up too bad I just put Frank's approach back in place to exclude URLs and titles in these two cases. 

Seems to work right on my device... though in simulator I get some weird warnings to console. But then, sharing in the simulator is weird in general. 