### PR TITLE
#39 clean cache on upgrade

### DIFF
--- a/99reddits.xcodeproj/project.pbxproj
+++ b/99reddits.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		FEDEA1631F9406B300D31EF0 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FEDEA1621F9406B300D31EF0 /* Main.storyboard */; };
 		FEE776BD1F89C6AE003703A1 /* FeedbackController.m in Sources */ = {isa = PBXBuildFile; fileRef = FEE776BC1F89C6AE003703A1 /* FeedbackController.m */; };
 		FEE776BF1F89D4D7003703A1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FEE776BE1F89D4D7003703A1 /* LaunchScreen.storyboard */; };
+		FEF113101FBAA95900FBC245 /* CacheCleaner.m in Sources */ = {isa = PBXBuildFile; fileRef = FEF1130F1FBAA95900FBC245 /* CacheCleaner.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -450,6 +451,8 @@
 		FEE776BB1F89C6AE003703A1 /* FeedbackController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FeedbackController.h; sourceTree = "<group>"; };
 		FEE776BC1F89C6AE003703A1 /* FeedbackController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FeedbackController.m; sourceTree = "<group>"; };
 		FEE776BE1F89D4D7003703A1 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		FEF1130E1FBAA95900FBC245 /* CacheCleaner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CacheCleaner.h; sourceTree = "<group>"; };
+		FEF1130F1FBAA95900FBC245 /* CacheCleaner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CacheCleaner.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -909,6 +912,8 @@
 				9C6584111FA028BF00D95BD5 /* TitleProvider.h */,
 				9C6584121FA02AFE00D95BD5 /* URLProvider.h */,
 				9C6584131FA02B2800D95BD5 /* URLProvider.m */,
+				FEF1130E1FBAA95900FBC245 /* CacheCleaner.h */,
+				FEF1130F1FBAA95900FBC245 /* CacheCleaner.m */,
 			);
 			name = Shared;
 			path = 99reddits/Shared;
@@ -1225,6 +1230,7 @@
 				8D68FDE014F8909000CDCF66 /* NIPagingScrollView.m in Sources */,
 				8D68FDE214F8909000CDCF66 /* NIPhotoAlbumScrollView.m in Sources */,
 				FE4738771F7CA0C300EC4828 /* ReviewManager.m in Sources */,
+				FEF113101FBAA95900FBC245 /* CacheCleaner.m in Sources */,
 				8D68FDE314F8909000CDCF66 /* NIPhotoScrollView.m in Sources */,
 				8D68FDE414F8909000CDCF66 /* NIPhotoScrubberView.m in Sources */,
 				8D68FDE514F8909000CDCF66 /* NIToolbarPhotoViewController.m in Sources */,

--- a/99reddits/Shared/CacheCleaner.h
+++ b/99reddits/Shared/CacheCleaner.h
@@ -1,0 +1,16 @@
+//
+//  CacheCleaner.h
+//  99reddits
+//
+//  Created by Pietro Rea on 11/13/17.
+//  Copyright © 2017 99 reddits. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface CacheCleaner : NSObject
+
+//Removes `ASIDownloadCache` on a background thread. `ASIDownloadCache` was used up until v2.8.2 of the app
++ (void)cleanCache;
+
+@end

--- a/99reddits/Shared/CacheCleaner.m
+++ b/99reddits/Shared/CacheCleaner.m
@@ -1,0 +1,29 @@
+//
+//  CacheCleaner.m
+//  99reddits
+//
+//  Created by Pietro Rea on 11/13/17.
+//  Copyright © 2017 99 reddits. All rights reserved.
+//
+
+#import "CacheCleaner.h"
+
+@implementation CacheCleaner
+
++ (void)cleanCache {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSString *path = [[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0] stringByAppendingPathComponent:@"ASIHTTPRequestCache"];
+        NSString *cachePath = [path stringByAppendingPathComponent:@"PermanentStore"];
+
+        NSError *fileManagerError;
+        BOOL success = [[NSFileManager defaultManager] removeItemAtPath:cachePath error:&fileManagerError];
+
+        if (!success) {
+            NSLog(@"%@: Could not remove cache. %@", NSStringFromClass(self), fileManagerError);
+        } else {
+            NSLog(@"%@: Removed cache successfully", NSStringFromClass(self));
+        }
+    });
+}
+
+@end

--- a/99reddits/Shared/PhotoItem.h
+++ b/99reddits/Shared/PhotoItem.h
@@ -25,7 +25,6 @@
 @property (nonatomic, copy) NSString *urlString;
 
 - (BOOL)isShowed;
-- (void)removeCaches;
 - (BOOL)isGif;
 - (NSURL *)photoViewControllerURL;
 

--- a/99reddits/Shared/PhotoItem.m
+++ b/99reddits/Shared/PhotoItem.m
@@ -8,7 +8,6 @@
 
 #import "PhotoItem.h"
 #import "NIHTTPRequest.h"
-#import "ASIDownloadCache.h"
 
 @implementation PhotoItem
 

--- a/99reddits/Shared/PhotoItem.m
+++ b/99reddits/Shared/PhotoItem.m
@@ -44,20 +44,6 @@
 	[encoder encodeObject:self.urlString forKey:@"url"];
 }
 
-- (void)removeCaches {
-	if (self.thumbnailString.length) {
-		NSURL *thumbnailURL = [NSURL URLWithString:self.thumbnailString];
-		if (thumbnailURL)
-			[[ASIDownloadCache sharedCache] removeCachedDataForURL:thumbnailURL];
-	}
-
-	if (self.urlString.length) {
-		NSURL *url = [NSURL URLWithString:self.urlString];
-		if (url)
-			[[ASIDownloadCache sharedCache] removeCachedDataForURL:url];
-	}
-}
-
 - (BOOL)isShowed {
 	if (appDelegate == nil)
 		appDelegate = (RedditsAppDelegate *)[[UIApplication sharedApplication] delegate];

--- a/99reddits/Shared/RedditsAppDelegate.m
+++ b/99reddits/Shared/RedditsAppDelegate.m
@@ -10,9 +10,9 @@
 #import "UserDef.h"
 #import "Reachability.h"
 #import "Flurry.h"
+#import "CacheCleaner.h"
 #import <Fabric/Fabric.h>
 #import <Crashlytics/Crashlytics.h>
-
 
 @implementation UINavigationController (iOS6OrientationFix)
 
@@ -60,6 +60,8 @@ void uncaughtExceptionHandler(NSException *exception) {
     fullImagesSet = [[NSMutableSet alloc] init];
 
     [self loadFromDefaults];
+
+    [CacheCleaner cleanCache];
 
     UIViewController *rootViewController = self.window.rootViewController;
     if ([rootViewController isMemberOfClass:[UISplitViewController class]]) {

--- a/99reddits/Shared/SubRedditItem.h
+++ b/99reddits/Shared/SubRedditItem.h
@@ -31,7 +31,6 @@
 @property (nonatomic) BOOL loading;
 @property (nonatomic) NSInteger unshowedCount;
 
-- (void)removeAllCaches;
 - (void)calUnshowedCount;
 
 @end

--- a/99reddits/Shared/SubRedditItem.m
+++ b/99reddits/Shared/SubRedditItem.m
@@ -8,7 +8,6 @@
 
 #import "SubRedditItem.h"
 #import "NIHTTPRequest.h"
-#import "ASIDownloadCache.h"
 
 @implementation SubRedditItem
 
@@ -71,23 +70,6 @@
 	[encoder encodeObject:self.afterString forKey:@"after"];
 	[encoder encodeObject:self.category forKey:@"category"];
 	[encoder encodeBool:self.subscribe forKey:@"subscribe"];
-}
-
-
-- (void)removeAllCaches {
-	for (PhotoItem *photo in photosArray) {
-		if (photo.thumbnailString.length) {
-			NSURL *thumbnailURL = [NSURL URLWithString:photo.thumbnailString];
-			if (thumbnailURL)
-				[[ASIDownloadCache sharedCache] removeCachedDataForURL:thumbnailURL];
-		}
-
-		if (photo.urlString.length) {
-			NSURL *url = [NSURL URLWithString:photo.urlString];
-			if (url)
-				[[ASIDownloadCache sharedCache] removeCachedDataForURL:url];
-		}
-	}
 }
 
 - (void)calUnshowedCount {


### PR DESCRIPTION
@TheLoombot please review

- On every fresh app launch, the app will try to delete its old `ASIDownloadCache` asynchronously on a background queue so you don't have to block the UI/know.
- Old implementation was writing to a very specific folder in Caches directory. New image loading doesn't write to the same place. 
- Tested building 2.8.1, swiping around, then building this branch on top and got a successful log message on app launch.

Old directory location (on simulator, at least):
- `/Users/pietrorea/Library/Developer/CoreSimulator/Devices/BF984329-5BD9-4B0F-9B4B-34F2AB383D50/data/Containers/Data/Application/D59952A5-8EC2-4846-9144-53DAE9B1FC28/Library/Caches/ASIHTTPRequestCache/PermanentStore`