### PR TITLE
#64 photo jumps when bars disappear

### DIFF
--- a/99reddits/Nimbus/Photos/NIToolbarPhotoViewController.m
+++ b/99reddits/Nimbus/Photos/NIToolbarPhotoViewController.m
@@ -280,6 +280,7 @@
 
 	UINavigationBar *navBar = self.navigationController.navigationBar;
 	navBar.barStyle = UIBarStyleDefault;
+    //Keep this here. The photo jerks when the nav bar is not marked translucent here.
 	navBar.translucent = YES;
 
 	_previousButton.enabled = [self.photoAlbumView hasPrevious];

--- a/99reddits/Nimbus/Photos/NIToolbarPhotoViewController.m
+++ b/99reddits/Nimbus/Photos/NIToolbarPhotoViewController.m
@@ -280,7 +280,7 @@
 
 	UINavigationBar *navBar = self.navigationController.navigationBar;
 	navBar.barStyle = UIBarStyleDefault;
-    //Keep this here. The photo jerks when the nav bar is not marked translucent here.
+    //Keep this here. The photo jerks when showing/hiding the chrome if the nav bar is not marked translucent here.
 	navBar.translucent = YES;
 
 	_previousButton.enabled = [self.photoAlbumView hasPrevious];

--- a/99reddits/Nimbus/Photos/NIToolbarPhotoViewController.m
+++ b/99reddits/Nimbus/Photos/NIToolbarPhotoViewController.m
@@ -280,7 +280,7 @@
 
 	UINavigationBar *navBar = self.navigationController.navigationBar;
 	navBar.barStyle = UIBarStyleDefault;
-	navBar.translucent = NO;
+	navBar.translucent = YES;
 
 	_previousButton.enabled = [self.photoAlbumView hasPrevious];
 	_nextButton.enabled = [self.photoAlbumView hasNext];


### PR DESCRIPTION
@TheLoombot please review

Fixing regression caused by https://github.com/TheLoombot/99-reddits/issues/82, where I changed the color of the nav bars in the photo browser to white. This was causing the photo to jerk again  when hiding/showing the chrome. 